### PR TITLE
fix: 최초 인증 시에만 오는 애플 닉네임에 대한 문자열 초기화

### DIFF
--- a/src/main/java/com/wl2c/elswhereuserservice/domain/oauth/apple/service/AppleOAuth2V2Service.java
+++ b/src/main/java/com/wl2c/elswhereuserservice/domain/oauth/apple/service/AppleOAuth2V2Service.java
@@ -63,7 +63,7 @@ public class AppleOAuth2V2Service {
     @Value("${oauth2.apple.revoke-token-uri}")
     private String appleRevokeTokenUri;
 
-    private String fullName;
+    private String fullName = "";
 
     public static final String OAUTH_AUTH_NAME = "oauth";
 


### PR DESCRIPTION
## Issue 번호
#62 


## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 기능 수정
- [ ] 리펙토링
- [ ] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 코드 스타일 업데이트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


## 작업 사항
- 최초 인증 시에만 오는 애플 닉네임에 대한 문자열 초기화
